### PR TITLE
Correctly strip prefix from paths

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -89,8 +89,8 @@ fn freeze_repos(dir: &str) -> anyhow::Result<()> {
                         ) {
                             let path = entry
                                 .path()
-                                .to_string_lossy()
-                                .strip_prefix(&dir)
+                                .strip_prefix(Path::new(dir))?
+                                .to_str()
                                 .unwrap()
                                 .to_string();
                             repos.insert(


### PR DESCRIPTION
This becomes the difference between

```toml
[healthchecks-rs]
remote_url = "git@github.com:msfjarvis/healthchecks-rs.git"
head = "refs/heads/develop"
```

and

```toml
["/healthchecks-rs"]
remote_url = "git@github.com:msfjarvis/healthchecks-rs.git"
head = "refs/heads/develop"
```
